### PR TITLE
Added override commands + minor changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 target
 /UltimateInventory.iml
+/libs/*.jar

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>Percyqaz.me</groupId>
     <artifactId>UltimateInventory</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,13 @@
             <version>12.0.0</version>
 			<scope>provided</scope>
 		</dependency>
+        <dependency>
+            <groupId>de.chriis</groupId>
+            <artifactId>advancedenderchest</artifactId>
+            <version>1.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/libs/AdvancedEnderchest.jar</systemPath>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>Percyqaz.me</groupId>
     <artifactId>UltimateInventory</artifactId>
-    <version>1.5</version>
+    <version>1.6</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
@@ -26,7 +26,7 @@
         </repository>
 		<repository>
 			<id>jeff-media-public</id>
-			<url>https://hub.jeff-media.com/nexus/repository/jeff-media-public/</url>
+			<url>https://repo.jeff-media.com/public/</url>
 		</repository>
     </repositories>
 
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>de.jeff_media</groupId>
 			<artifactId>ChestSortAPI</artifactId>
-			<version>13.0.0-SNAPSHOT</version>
+            <version>12.0.0</version>
 			<scope>provided</scope>
 		</dependency>
     </dependencies>

--- a/src/main/java/me/Percyqaz/UltimateInventory/InventoryListener.java
+++ b/src/main/java/me/Percyqaz/UltimateInventory/InventoryListener.java
@@ -287,11 +287,9 @@ public class InventoryListener implements Listener
     }
 
     private void CloseShulkerbox(HumanEntity player) {
-        plugin.getLogger().info("Closing shulker box for player: " + player.getName());
 
         ItemStack shulkerItem = openShulkerBoxes.get(player.getUniqueId());
         if (shulkerItem == null) {
-            plugin.getLogger().warning("No shulker item found for player: " + player.getName());
             return;
         }
 
@@ -304,7 +302,6 @@ public class InventoryListener implements Listener
         NamespacedKey nbtKey = new NamespacedKey(plugin, "__shulkerbox_plugin");
         if (data.has(nbtKey, PersistentDataType.STRING)) {
             data.remove(nbtKey);
-            plugin.getLogger().info("Removed NBT locking for shulker box");
         }
 
         meta.setBlockState(shulkerbox);
@@ -313,18 +310,14 @@ public class InventoryListener implements Listener
         // Get the stored chest ID
         String chestId = playerChestIds.get(player.getUniqueId());
         if (chestId == null) {
-            plugin.getLogger().warning("No chest ID found for player: " + player.getName());
             return;
         }
 
         // Get the stored slot information
         Integer slot = shulkerBoxSlots.get(player.getUniqueId());
         if (slot == null) {
-            plugin.getLogger().warning("No slot information found for player: " + player.getName());
             return;
         }
-
-        plugin.getLogger().info("ChestID: " + chestId + ", Slot: " + slot);
 
         // Check if the inventory is an AEC virtual chest
         Boolean isAec = isAecVirtualChest.get(player.getUniqueId());
@@ -332,7 +325,6 @@ public class InventoryListener implements Listener
             // Retrieve the existing chest data asynchronously
             EnderchestManager.getItemsByChestID(player.getUniqueId(), chestId, existingContents -> {
                 if (existingContents == null) {
-                    plugin.getLogger().warning("No existing contents found for chest ID: " + chestId);
                     return;
                 }
                 existingContents[slot] = shulkerItem;
@@ -347,7 +339,6 @@ public class InventoryListener implements Listener
         openShulkerBoxes.remove(player.getUniqueId());
         shulkerBoxSlots.remove(player.getUniqueId()); // Remove the slot information
         isAecVirtualChest.remove(player.getUniqueId()); // Remove the flag
-        plugin.getLogger().info("Removed shulker box from openShulkerBoxes for player: " + player.getName());
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)

--- a/src/main/java/me/Percyqaz/UltimateInventory/UltimateInventory.java
+++ b/src/main/java/me/Percyqaz/UltimateInventory/UltimateInventory.java
@@ -26,17 +26,16 @@ public class UltimateInventory extends JavaPlugin {
 
         PluginManager pm = getServer().getPluginManager();
 
-        config.addDefault("enableShulkerbox", true);
-        config.addDefault("enableEnderChest", true);
-        config.addDefault("enableCraftingTable", true);
-        if (isPaper)
-        {
-            config.addDefault("enableSmithingTable", true);
-            config.addDefault("enableStoneCutter", true);
-            config.addDefault("enableGrindstone", true);
-            config.addDefault("enableCartographyTable", true);
-            config.addDefault("enableLoom", true);
-            config.addDefault("enableAnvil", false);
+        addItemConfig("shulkerbox", true, false, "");
+        addItemConfig("enderChest", true, false, "");
+        addItemConfig("craftingTable", true, false, "");
+        if (isPaper) {
+            addItemConfig("smithingTable", true, false, "");
+            addItemConfig("stoneCutter", true, false, "");
+            addItemConfig("grindstone", true, false, "");
+            addItemConfig("cartographyTable", true, false, "");
+            addItemConfig("loom", true, false, "");
+            addItemConfig("anvil", false, false, "");
         }
         config.addDefault("usePermissions", false);
 
@@ -44,10 +43,15 @@ public class UltimateInventory extends JavaPlugin {
         saveConfig();
 
         pm.registerEvents(new InventoryListener(this, config, isPaper), this);
-        if (pm.getPlugin("ChestSort") != null)
-        {
+        if (pm.getPlugin("ChestSort") != null) {
             pm.registerEvents(new ChestSortListener(this), this);
             this.getLogger().info("ChestSort detected, enabling compatibility support");
         }
+    }
+
+    private void addItemConfig(String itemName, boolean enable, boolean override, String command) {
+        config.addDefault(itemName + ".enable", enable);
+        config.addDefault(itemName + ".override", override);
+        config.addDefault(itemName + ".command", command);
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: UltimateInventory
-version: 1.5
+version: 1.7
 author: Percyqaz
 main: me.Percyqaz.UltimateInventory.UltimateInventory
 api-version: '1.20'


### PR DESCRIPTION
Added override commands, modified config, updated downgraded ChestSortAPI to available version, bumped plugin version to 1.6.

The config now generates each workbench type with two new config options, override (bool) and command (string). If override is enabled, then the command is executed by the player. This allows the server admin to link into GUIs from other plugins, or execute skripts.

I fully don't expect this to be pulled in, I'm just making this PR to show that I did it :D
(Full disclosure, I don't know Java, so I made this with Copilot..)